### PR TITLE
Dont trigger workflow for markdown files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,12 @@ name: Build CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   schedule:
     - cron: '0 8 * * 1'
 


### PR DESCRIPTION
This workflow will not run when only markdown files were changed.