### PR TITLE
Build multiple environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Build PlatformIO project
         env:
           PLATFORMIO_ENV: ${{ matrix.platformio_env }}
+          PLATFORMIO_BUILD_FLAGS: -DCONFIG_TWOMES_TEST_SERVER
         run: pio run -e $PLATFORMIO_ENV
 
       # Perform the code analysis.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,16 @@ jobs:
     environment: production
     strategy:
       matrix:
-        # List all of the PlatformIO platforms to build
-        platformio_env: [ESP32DEV, M5STACK_COREINK]
+        # List all of the PlatformIO platforms to build.
+        platformio_env: 
+          - ESP32DEV
+          - M5STACK_COREINK
+
+        # Twomes server environments to build for.
+        twomes_server_env:
+          - TEST_SERVER
+          - PRODUCTION_SERVER
+
     env:
       # Directory where the to-be-archived files are.
       BUILD_DIR: .pio/build/${{ matrix.platformio_env }}
@@ -50,6 +58,7 @@ jobs:
       - name: Build PlatformIO project
         env:
           PLATFORMIO_ENV: ${{ matrix.platformio_env }}
+          PLATFORMIO_BUILD_FLAGS: -DCONFIG_TWOMES_${{ matrix.twomes_server_env }}
         run: pio run -e $PLATFORMIO_ENV
 
       # Create secure_boot_signing_key.pem from GH secret SECURE_BOOTLOADER_SIGNING_KEY.
@@ -66,7 +75,7 @@ jobs:
       
       # Set ARCHIVE_NAME variable from ARCHIVE_PREFIX and tag name.
       - name: Set ARCHIVE_NAME
-        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${{ matrix.platformio_env }}_${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}_${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       
       # Archive binary files.
       - name: Archive binary files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Sign firmware
         uses: espressif/esp-idf-ci-action@main
         with:
-          command: espsecure.py sign_data -v1 --keyfile secure_boot_signing_key.pem --output $BUILD_DIR/firmware-signed_${{ matrix.platformio_env }}.bin $BUILD_DIR/firmware.bin
+          command: espsecure.py sign_data -v1 --keyfile secure_boot_signing_key.pem --output $BUILD_DIR/firmware-signed_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}.bin $BUILD_DIR/firmware.bin
       
       # Set ARCHIVE_NAME variable from ARCHIVE_PREFIX and tag name.
       - name: Set ARCHIVE_NAME
@@ -90,4 +90,4 @@ jobs:
           draft: true
           files: |
             ${{ env.BUILD_DIR }}/${{ env.ARCHIVE_NAME }}.zip
-            ${{ env.BUILD_DIR }}/firmware-signed_${{ matrix.platformio_env }}.bin
+            ${{ env.BUILD_DIR }}/firmware-signed_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ build_flags =
 ;   -DCONFIG_TWOMES_STRESS_TEST         ;line commented = disabled; line uncommented = enabled
     -DCONFIG_TWOMES_PRESENCE_DETECTION  ;line commented = disabled; line uncommented = enabled
 ;   -DCONFIG_TWOMES_PRESENCE_DETECTION_PARALLEL ;line commented = disabled; line uncommented = enabled; keep disabled for now
-    -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
+;   -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
 ;   -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
 ;   -DCONFIG_TWOMES_OTA_FIRMWARE_UPDATE ;line commented = disabled; line uncommented = enabled
     -D"$PIOENV"


### PR DESCRIPTION
Create release bundles for TEST_SERVER and PRODUCTION_SERVER. signed binaries for OTA firmware downloads are created as `firmware-signed_PLATFORM_ENVIRONMENT.bin`.

## Test
See the result of the workflow here: https://github.com/n-vr/twomes-presence-detector/releases/tag/v1.0.1-workflow_test.3